### PR TITLE
Fix internal module requring

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,12 +4,16 @@ module.exports = (context, request, callback) => {
 
   if (context.indexOf('tns-core-modules') !== -1
     || context.indexOf('nativescript-') !== -1
-    || /^(tns-core-modules)/i.test(request)
+    || /^tns-core-modules/i.test(request)
     || /^(ui|application)/i.test(request)) {
 
-    // Support plugins requiring sibling files by rewriting './' into 'context/'
-    if (request.indexOf('./') === 0) {
-      request = path.join(path.basename(context), request.substring(2));
+    if (request.indexOf('../') === 0 || request.indexOf('./') === 0) {
+      let index = context.indexOf('node_modules') + 'node_modules'.length + 1;
+
+      request = path.normalize(path.join(context.substring(index).replace(/\\/g, '/'), request)).replace(/\\/g, '/');
+    }
+    else if (/^(ui|application)/i.test(request)) {
+      request = `tns-core-modules/${request}`.replace(/\\/g, '/');
     }
 
     return callback(null, 'commonjs ' + request);


### PR DESCRIPTION
Inside packages `"tns-core-modules"` and `"nativescript-*"` requiring sub modules with relative paths fails (mostly like `require('../a-sub-module')`). This change fixes that.